### PR TITLE
Fixed a bug that caused only the most shallow scope to be printed

### DIFF
--- a/src/log4net.Extensions.AspNetCore/log4netLogger.cs
+++ b/src/log4net.Extensions.AspNetCore/log4netLogger.cs
@@ -104,10 +104,11 @@ namespace log4net.Extensions.AspNetCore
         {
             var current = log4netScope.Current;
 
-            if(current != null)
+            while(current != null)
             {
                 messageBuilder.Append($" => {current}");
-            }
+				current = current.Parent;
+			}
         }
     }
 }


### PR DESCRIPTION
The previous code logs only 1 level of scope which is inconsistent with the loggers provided by Microsoft which log the entire scope hierarchy.