### PR TITLE
Added extension methods for ILoggingBuilder to register the log4net logger

### DIFF
--- a/src/log4net.Extensions.AspNetCore/log4net.Extensions.AspNetCore.csproj
+++ b/src/log4net.Extensions.AspNetCore/log4net.Extensions.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <Authors>Scott Clewell</Authors>
     <Company />
     <Product>log4net</Product>
@@ -14,11 +14,13 @@
     <RepositoryUrl>https://github.com/Scottz0r/log4net.Extensions.AspNetCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <Version>1.0.0</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" Condition="'$(TargetFramework)'=='netstandard1.5'" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 
 </Project>

--- a/src/log4net.Extensions.AspNetCore/log4netExtensions.cs
+++ b/src/log4net.Extensions.AspNetCore/log4netExtensions.cs
@@ -10,7 +10,40 @@ namespace log4net.Extensions.AspNetCore
 {
     public static class log4netExtensions
     {
-        public static void AddLog4Net(this ILoggerFactory loggerFactory, bool enableScopes = false)
+
+#if NETSTANDARD2_0
+		public static ILoggingBuilder AddLog4Net(this ILoggingBuilder loggingBuilder) {
+			return loggingBuilder.AddLog4Net(false);
+		}
+		public static ILoggingBuilder AddLog4Net(this ILoggingBuilder loggingBuilder, bool enableScopes) {
+			loggingBuilder.AddProvider(new log4netLogProvider(enableScopes));
+			return loggingBuilder;
+		}
+		public static ILoggingBuilder AddLog4Net(this ILoggingBuilder loggingBuilder, string configurationPath) {
+			return loggingBuilder.AddLog4Net(false, configurationPath, Assembly.GetEntryAssembly());
+		}
+		public static ILoggingBuilder AddLog4Net(this ILoggingBuilder loggingBuilder, string configurationPath, Assembly repositoryAssembly) {
+			return loggingBuilder.AddLog4Net(false, configurationPath, repositoryAssembly);
+		}
+		public static ILoggingBuilder AddLog4Net(this ILoggingBuilder loggingBuilder, bool enableScopes, string configurationPath, Assembly repositoryAssembly) {
+			loggingBuilder.AddLog4Net(enableScopes);
+			loggingBuilder.ConfigureLog4Net(configurationPath, repositoryAssembly);
+			return loggingBuilder;
+		}
+
+		public static ILoggingBuilder ConfigureLog4Net(this ILoggingBuilder loggingBuilder, string configurationPath) {
+			loggingBuilder.ConfigureLog4Net(configurationPath, Assembly.GetEntryAssembly());
+			return loggingBuilder;
+		}
+
+		public static ILoggingBuilder ConfigureLog4Net(this ILoggingBuilder loggingBuilder, string configurationPath, Assembly repositoryAssembly) {
+			var logRepository = LogManager.GetRepository(repositoryAssembly);
+			XmlConfigurator.ConfigureAndWatch(logRepository, new FileInfo(configurationPath));
+			return loggingBuilder;
+		}
+#endif
+
+		public static void AddLog4Net(this ILoggerFactory loggerFactory, bool enableScopes = false)
         {
             loggerFactory.AddProvider(new log4netLogProvider(enableScopes: enableScopes));
         }


### PR DESCRIPTION
The new 2.0.0 version of the Logging abstractions adds a new (recommended) way to register logging providers using the ILoggingBuilder interface.

This PR adds the capability to register the Log4Net provider with the factory using the ILoggingBuilder while maintaining compatibility with projects that use the older netstandard1.5 SDK (which doesn't support the 2.0.0 version of the Logging abstractions)

Also added a few convenience overloads to add and configure the Log4Net logger in using a single ILoggingBuilder extension method overload.